### PR TITLE
Some fixes

### DIFF
--- a/FoundationNavWalker.class.php
+++ b/FoundationNavWalker.class.php
@@ -33,7 +33,7 @@ class FoundationNavWalker extends Walker_Nav_Menu {
     $id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
 
     if ( $depth === 0 ) {
-      $output .= '<li' . $id . $value . $class_names . '><label>' . esc_attr( $item->title ) . '</label>';
+      $output .= '<li' . $id . $value . $class_names . '><label>' . esc_attr( $item->title ) . '</label></li>';
     }
 
     if ( $depth === 1) {
@@ -50,6 +50,13 @@ class FoundationNavWalker extends Walker_Nav_Menu {
   public function end_lvl( &$output, $depth = 0, $args = array() ) {
     $indent = str_repeat( "\t", $depth);
     $output .= "\n$indent\n";
+  }
+  
+  //End li only if child level
+  public function end_el( &$output, $item, $depth = 0, $args = array() ) {
+    if ( $depth === 1) {
+      $output .= "</li>\n";
+    }
   }
 }
 

--- a/FoundationNavWalker.class.php
+++ b/FoundationNavWalker.class.php
@@ -32,6 +32,41 @@ class FoundationNavWalker extends Walker_Nav_Menu {
     $id = apply_filters( 'nav_menu_item_id', 'menu-item-'. $item->ID, $item, $args );
     $id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
 
+    //attributes to menu item's <a>
+    $atts = array();
+    $atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
+    $atts['target'] = ! empty( $item->target )     ? $item->target     : '';
+    $atts['rel']    = ! empty( $item->xfn )        ? $item->xfn        : '';
+    $atts['href']   = ! empty( $item->url )        ? $item->url        : '';
+
+    /**
+     * Filter the HTML attributes applied to a menu item's <a>.
+     *
+     * @since 3.6.0
+     *
+     * @param array $atts {
+     *     The HTML attributes applied to the menu item's <a>, empty strings are ignored.
+     *
+     *     @type string $title  The title attribute.
+     *     @type string $target The target attribute.
+     *     @type string $rel    The rel attribute.
+     *     @type string $href   The href attribute.
+     * }
+     * @param object $item The current menu item.
+     * @param array  $args An array of arguments. @see wp_nav_menu()
+     */
+    $atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args );
+
+    $attributes = '';
+    foreach ( $atts as $attr => $value ) {
+      if ( ! empty( $value ) ) {
+        $value = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+        $attributes .= ' ' . $attr . '="' . $value . '"';
+      }
+    }
+
+
+
     if ( $depth === 0 ) {
       $output .= '<li' . $id . $value . $class_names . '><label>' . esc_attr( $item->title ) . '</label></li>';
     }
@@ -40,7 +75,12 @@ class FoundationNavWalker extends Walker_Nav_Menu {
       $output .= '<li' . $id . $value . $class_names .'>';
 
       if (!empty($item->url)) {
-        $output .= '<a href="' . $item->url . '">' . $item->title . '</a>';
+        $output .= $args->before;
+        $output .= '<a'. $attributes .'>';
+        /** This filter is documented in wp-includes/post-template.php */
+        $output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
+        $output .= '</a>';
+        $$output .= $args->after;
       }
 
     }


### PR DESCRIPTION
I realized that parent level \<li\> should be closed in function start_el, instead of end_el.
That is because off canvas menu list is not nested.
So you can just discard my former pull_request, and add blank end_el function.
This time, I overwritten end_el to close only child(second) level \<li\>.
Whichever would work I guess.

Another commit I made is to add some attributes to menu item's \<a\>, like target="_blank".